### PR TITLE
allow regions to be string format

### DIFF
--- a/src/cultionet/model.py
+++ b/src/cultionet/model.py
@@ -99,7 +99,7 @@ def fit(
         mode='min',
         monitor='loss',
         every_n_train_steps=0,
-        every_n_val_epochs=1
+        every_n_val_epochs=1 # this parameter will become invalid with newer version of pytorch-lightning
     )
 
     cb_val_loss = ModelCheckpoint(monitor='val_loss')

--- a/src/cultionet/scripts/config.yml
+++ b/src/cultionet/scripts/config.yml
@@ -2,11 +2,7 @@ image_vis:
   - evi2
   - gcvi
   - kndvi
-
-# The regions to process (start, end)
-regions:
-  - 1
-  - 1
+  - green
 
 # End years (i.e., 2020 = 2019 planting/harvest year)
 # 2019 = 2018 CDL

--- a/src/cultionet/scripts/config.yml
+++ b/src/cultionet/scripts/config.yml
@@ -4,6 +4,11 @@ image_vis:
   - kndvi
   - green
 
+regions:
+  - 1
+  - 1
+
+region_id_file:
 # End years (i.e., 2020 = 2019 planting/harvest year)
 # 2019 = 2018 CDL
 # 2020 = 2019 CDL

--- a/src/cultionet/scripts/config.yml
+++ b/src/cultionet/scripts/config.yml
@@ -2,13 +2,12 @@ image_vis:
   - evi2
   - gcvi
   - kndvi
-  - green
 
 regions:
   - 1
   - 1
 
-region_id_file:
+region_id_file: !!null
 # End years (i.e., 2020 = 2019 planting/harvest year)
 # 2019 = 2018 CDL
 # 2020 = 2019 CDL

--- a/src/cultionet/scripts/config.yml
+++ b/src/cultionet/scripts/config.yml
@@ -3,11 +3,14 @@ image_vis:
   - gcvi
   - kndvi
 
+# The regions to process (start, end)
 regions:
   - 1
   - 1
 
+# The region file path
 region_id_file: !!null
+
 # End years (i.e., 2020 = 2019 planting/harvest year)
 # 2019 = 2018 CDL
 # 2020 = 2019 CDL

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -16,10 +16,14 @@ from cultionet.data.utils import create_network_data, NetworkDataset
 
 import torch
 import geopandas as gpd
+import pandas as pd
 import yaml
 
 
 logger = logging.getLogger(__name__)
+
+geo_id_data = pd.read_csv('~/geo_id_grid_list.csv')
+geo_id_list = geo_id_data['geo_id_grid'].unique().tolist() 
 
 DEFAULT_AUGMENTATIONS = ['none', 'fliplr', 'flipud', 'flipfb',
                          'rot90', 'rot180', 'rot270',
@@ -213,7 +217,7 @@ def persist_dataset(args):
     ref_res_lists = [args.ref_res]
 
     inputs = model_preprocessing.TrainInputs(
-        regions=config['regions'],
+        regions=geo_id_list,
         years=config['years'],
         lc_path=config['lc_path']
     )

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -222,14 +222,14 @@ def persist_dataset(args):
 
     
     if region_as_file:
-      file_path = config['region_id_file']
-      if not Path(file_path).is_file():
-          raise IOError('The id file does not exist')
-      id_data = pd.read_csv(file_path)
-      assert "id" in id_data.columns, f"id column not found in {file_path}."
-      regions = id_data['id'].unique().tolist()  
+        file_path = config['region_id_file']
+        if not Path(file_path).is_file():
+            raise IOError('The id file does not exist')
+        id_data = pd.read_csv(file_path)
+        assert "id" in id_data.columns, f"id column not found in {file_path}."
+        regions = id_data['id'].unique().tolist()
     else:
-      regions = list(range(config['regions'][0], config['regions'][1]+1))
+        regions = list(range(config['regions'][0], config['regions'][1]+1))
     
 
     inputs = model_preprocessing.TrainInputs(

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -214,14 +214,14 @@ def persist_dataset(args):
     ref_res_lists = [args.ref_res]
     
     region_as_list = config['regions'] is not None
-    region_as_file = jobs["region_id_file"] is not None
+    region_as_file = config["region_id_file"] is not None
 
     assert (
         region_as_list or region_as_file
     ), "Only submit region as a list or as a given file"
 
     
-    if config['region_id_file'] is not None:
+    if region_as_file:
       file_path = config['region_id_file']
       if not Path(file_path).is_file():
           raise IOError('The id file does not exist')

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -16,14 +16,10 @@ from cultionet.data.utils import create_network_data, NetworkDataset
 
 import torch
 import geopandas as gpd
-import pandas as pd
 import yaml
 
 
 logger = logging.getLogger(__name__)
-
-geo_id_data = pd.read_csv('~/geo_id_grid_list.csv')
-geo_id_list = geo_id_data['geo_id_grid'].unique().tolist() 
 
 DEFAULT_AUGMENTATIONS = ['none', 'fliplr', 'flipud', 'flipfb',
                          'rot90', 'rot180', 'rot270',
@@ -215,9 +211,17 @@ def persist_dataset(args):
     config = open_config(args.config_file)
     project_path_lists = [args.project_path]
     ref_res_lists = [args.ref_res]
+  
+    if hasattr(args, 'region_id_file'):
+      if not Path(args.region_id_file).is_file():
+          raise IOError('The id file does not exist')
+      id_data = pd.read_csv(args.region_id_file)
+      assert "id" in id_data.columns, f"id column not found in {args.region_id_file}."
+      regions = id_data['id'].unique().tolist()  
+    
 
     inputs = model_preprocessing.TrainInputs(
-        regions=geo_id_list,
+        regions=regions,
         years=config['years'],
         lc_path=config['lc_path']
     )

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -16,6 +16,7 @@ from cultionet.data.utils import create_network_data, NetworkDataset
 
 import torch
 import geopandas as gpd
+import pandas as pd
 import yaml
 
 

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -213,6 +213,14 @@ def persist_dataset(args):
     project_path_lists = [args.project_path]
     ref_res_lists = [args.ref_res]
     
+    region_as_list = config['regions'] is not None
+    region_as_file = jobs["region_id_file"] is not None
+
+    assert (
+        region_as_list or region_as_file
+    ), "Only submit region as a list or as a given file"
+
+    
     if config['region_id_file'] is not None:
       file_path = config['region_id_file']
       if not Path(file_path).is_file():
@@ -220,6 +228,8 @@ def persist_dataset(args):
       id_data = pd.read_csv(file_path)
       assert "id" in id_data.columns, f"id column not found in {file_path}."
       regions = id_data['id'].unique().tolist()  
+    else:
+      regions = config['regions']
     
 
     inputs = model_preprocessing.TrainInputs(

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -211,12 +211,13 @@ def persist_dataset(args):
     config = open_config(args.config_file)
     project_path_lists = [args.project_path]
     ref_res_lists = [args.ref_res]
-  
-    if hasattr(args, 'region_id_file'):
-      if not Path(args.region_id_file).is_file():
+    
+    if config['region_id_file'] is not None:
+      file_path = config['region_id_file']
+      if not Path(file_path).is_file():
           raise IOError('The id file does not exist')
-      id_data = pd.read_csv(args.region_id_file)
-      assert "id" in id_data.columns, f"id column not found in {args.region_id_file}."
+      id_data = pd.read_csv(file_path)
+      assert "id" in id_data.columns, f"id column not found in {file_path}."
       regions = id_data['id'].unique().tolist()  
     
 

--- a/src/cultionet/scripts/cultionet.py
+++ b/src/cultionet/scripts/cultionet.py
@@ -229,7 +229,7 @@ def persist_dataset(args):
       assert "id" in id_data.columns, f"id column not found in {file_path}."
       regions = id_data['id'].unique().tolist()  
     else:
-      regions = config['regions']
+      regions = list(range(config['regions'][0], config['regions'][1]+1))
     
 
     inputs = model_preprocessing.TrainInputs(

--- a/src/cultionet/utils/model_preprocessing.py
+++ b/src/cultionet/utils/model_preprocessing.py
@@ -25,9 +25,7 @@ class TrainInputs(object):
     )
 
     def __attrs_post_init__(self):
-        start_region = self.regions[0]
-        end_region = self.regions[1]
-        region_list = list(range(start_region, end_region+1))
+        region_list = self.regions
         self.regions_lists: T.List[T.List[str]] = [region_list]
         self.year_lists: T.List[T.List[int]] = [self.years]
         self.lc_paths_lists: T.List[str] = [self.lc_path]


### PR DESCRIPTION
This PR is to allow grid to be other format in file name. Instead of an integer of six character length, this allows string format, integer format, etcc...

- [ ] scripts/config.yml - remove region part + add new features

- [ ] scripts/create_dataset.py – in persist_dataset, change regions into a list of hash polygons instead of CONFIG['regions']

- [ ] src/cultionet/scripts/cultionet.py – in persist_dataset, change regions into a list of hash polygons instead of CONFIG['regions']

- [ ] src/cultionet/utils/model_preprocessing.py – in class TrainInputs, attrs_post_init(self), remove region_list as list of range number into region_list = self.regions