### PR TITLE
jgrss/setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,14 +23,16 @@ package_dir=
 packages=find:
 include_package_data = True
 setup_requires =
-    cython>=0.29.0
+    Cython>=0.29.0
+python_requires =
+    >=3.8.0,<4.0.0
 install_requires =
     attrs>=21.0
     frozendict>=2.2.0
     frozenlist>=1.3.0
     numpy>=1.22.0
     scipy>=1.5.0
-    pandas>=1.*,<=1.3.5
+    pandas>=1.0.0,<=1.3.5
     geopandas>=0.10.0
     rasterio
     shapely>=1.8.0
@@ -40,7 +42,7 @@ install_requires =
     decorator==4.4.2
     rtree>=0.9.7
     graphviz>=0.19.0
-    tqdm>=4.62.*
+    tqdm>=4.62.0
     pyDeprecate==0.3.1
     future>=0.17.1
     tensorboard>=2.2.0
@@ -48,10 +50,10 @@ install_requires =
     pytorch_lightning>=1.7.6
     torchmetrics>=0.10.0,<0.11.0
     ray>=2.0.0
-    geowombat@git+https://github.com/jgrss/geowombat.git@v2.0.19
+    geowombat@git+https://github.com/jgrss/geowombat.git@v2.1.1
     tsaug@git+https://github.com/jgrss/tsaug.git
     geosample@git+https://github.com/jgrss/geosample.git
-    setuptools>=65.5.1;python_version>='3.8.12'
+    setuptools>=65.5.1
 
 [options.extras_require]
 docs = numpydoc


### PR DESCRIPTION
Recent builds are failing because `setuptools` is not parsing `setup.cfg` properly. This PR pins required packages to full versions.